### PR TITLE
feat: moving GITHUB_REPOS to read from a txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Authentication can either via a Github Token or the Github App Authentication 3 
 | Github App Private Key | app_private_key, gpk | GITHUB_APP_PRIVATE_KEY | - | Github App Authentication Private Key |
 | Github Refresh | github_refresh, gr | GITHUB_REFRESH | 30 | Refresh time Github Actions status in sec |
 | Github Organizations | github_orgas, go | GITHUB_ORGAS | - | List all organizations you want get informations. Format \<orga1>,\<orga2>,\<orga3> (like test1,test2) |
-| Github Repositories List File | repo_list_file | REPO_LIST_FILE | - | [Optional] List all repositories you want get informations. Format \<orga>/\<repo>,\<orga>/\<repo2>,\<orga>/\<repo3> (like test/test). Defaults to all repositories owned by the organizations. |
+| Github Repositories List File | repo_list_file | REPO_LIST_FILE | - | [Optional] List all repositories you want get informations. Multiline format, check `example_repo.txt`. Defaults to all repositories owned by the organizations. |
 | Exporter port | port, p | PORT | 9999 | Exporter port |
 | Github Api URL | github_api_url, url | GITHUB_API_URL | api.github.com | Github API URL (primarily for Github Enterprise usage) |
 | Github Enterprise Name | enterprise_name | ENTERPRISE_NAME | "" | Enterprise name. Needed for enterprise endpoints (/enterprises/{ENTERPRISE_NAME}/*). Currently used to get Enterprise level tunners status |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Authentication can either via a Github Token or the Github App Authentication 3 
 | Github App Private Key | app_private_key, gpk | GITHUB_APP_PRIVATE_KEY | - | Github App Authentication Private Key |
 | Github Refresh | github_refresh, gr | GITHUB_REFRESH | 30 | Refresh time Github Actions status in sec |
 | Github Organizations | github_orgas, go | GITHUB_ORGAS | - | List all organizations you want get informations. Format \<orga1>,\<orga2>,\<orga3> (like test1,test2) |
-| Github Repos | github_repos, grs | GITHUB_REPOS | - | [Optional] List all repositories you want get informations. Format \<orga>/\<repo>,\<orga>/\<repo2>,\<orga>/\<repo3> (like test/test). Defaults to all repositories owned by the organizations. |
+| Github Repositories List File | repo_list_file | REPO_LIST_FILE | - | [Optional] List all repositories you want get informations. Format \<orga>/\<repo>,\<orga>/\<repo2>,\<orga>/\<repo3> (like test/test). Defaults to all repositories owned by the organizations. |
 | Exporter port | port, p | PORT | 9999 | Exporter port |
 | Github Api URL | github_api_url, url | GITHUB_API_URL | api.github.com | Github API URL (primarily for Github Enterprise usage) |
 | Github Enterprise Name | enterprise_name | ENTERPRISE_NAME | "" | Enterprise name. Needed for enterprise endpoints (/enterprises/{ENTERPRISE_NAME}/*). Currently used to get Enterprise level tunners status |

--- a/example_repo.txt
+++ b/example_repo.txt
@@ -1,0 +1,2 @@
+org-name/repo-name-1
+org-name/repo-name-2

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ var (
 	Debug          bool
 	EnterpriseName string
 	WorkflowFields string
+	RepoFilePath   string
 )
 
 // InitConfiguration - set configuration from env vars or command parameters
@@ -86,13 +87,6 @@ func InitConfiguration() []cli.Flag {
 			Usage:       "List all organizations you want get informations. Format <orga>,<orga2>,<orga3> (like test,test2)",
 			Destination: &Github.Organizations,
 		},
-		&cli.StringSliceFlag{
-			Name:        "github_repos",
-			Aliases:     []string{"grs"},
-			EnvVars:     []string{"GITHUB_REPOS"},
-			Usage:       "List all repositories you want get informations. Format <orga>/<repo>,<orga>/<repo2>,<orga>/<repo3> (like test/test)",
-			Destination: &Github.Repositories,
-		},
 		&cli.BoolFlag{
 			Name:        "debug_profile",
 			EnvVars:     []string{"DEBUG_PROFILE"},
@@ -126,6 +120,12 @@ func InitConfiguration() []cli.Flag {
 			Value:       100 * 1024 * 1024,
 			Usage:       "Size of Github HTTP cache in bytes",
 			Destination: &Github.CacheSizeBytes,
+		},
+		&cli.StringFlag{
+			Name:        "repo_list_file",
+			Usage:       "Path to the repo list file",
+			EnvVars:     []string{"REPO_LIST_FILE"},
+			Destination: &RepoFilePath,
 		},
 	}
 }

--- a/pkg/metrics/github_fetcher.go
+++ b/pkg/metrics/github_fetcher.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -81,8 +82,12 @@ func periodicGithubFetcher() {
 
 		// Fetch repositories (if dynamic)
 		var repos_to_fetch []string
-		if len(config.Github.Repositories.Value()) > 0 {
-			repos_to_fetch = config.Github.Repositories.Value()
+		if len(config.RepoFilePath) > 0 {
+			data, err := os.ReadFile(config.RepoFilePath)
+			if err != nil {
+				log.Fatalf("error reading file %s", err)
+			}
+			repos_to_fetch = strings.Split(string(data), "\n")
 		} else {
 			for _, orga := range config.Github.Organizations.Value() {
 				repos_to_fetch = append(repos_to_fetch, getAllReposForOrg(orga)...)


### PR DESCRIPTION
Listing lot of repositories as comma separated long string sometime is not really nice and convenient.
So, I'd created a new flag called `repo_list_file` or env var `REPO_LIST_FILE` that read a multiline string text file containing list of repositories.
Example of file can be found on `example_repo.txt`.
