### PR TITLE
prevent panic when dealing with unexpected repo names

### DIFF
--- a/pkg/metrics/github_fetcher.go
+++ b/pkg/metrics/github_fetcher.go
@@ -100,6 +100,10 @@ func periodicGithubFetcher() {
 		ww := make(map[string]map[int64]github.Workflow)
 		for _, repo := range repos_to_fetch {
 			r := strings.Split(repo, "/")
+			if len(r) != 2 {
+				log.Printf("Skipping invalid repository %s", repo)
+				continue
+			}
 			workflows_for_repo := getAllWorkflowsForRepo(r[0], r[1])
 			if len(workflows_for_repo) == 0 {
 				continue


### PR DESCRIPTION
We have seen one example where the repo name is the last empty line of the file. There could  also be other user errors. Assuming that the user input is correct is bad practice when it's very easy to just check the input.